### PR TITLE
namespace added to composer's autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,5 +12,10 @@
     "require": {
         "freshwork/transbank": "^1.0",
         "miguelalcaino/payment-gateway": "^1.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "GabrielCorrea\\WebpayBundle\\": "src"
+        }
     }
 }


### PR DESCRIPTION
This PR adds the missing GabrielCorrea\WebpayBundle namespace to make the bundle work